### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 bither-ios
 ==========
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5657864828898101003ae8da&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5657864828898101003ae8da/build/latest)
 
 Bither is a simple and secure Bitcoin wallet! You can find Bither on [App Store](https://itunes.apple.com/app/bither/id899478936).
 


### PR DESCRIPTION
We really liked bither and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/5657864828898101003ae8da/build/latest) are the builds we've completed for bither so far.

![screen shot 2015-11-26 at 2 40 22 pm](https://cloud.githubusercontent.com/assets/13876667/11431395/cc3e3bde-944b-11e5-99e9-5b6018670e23.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.

-the buddybuild team

P.S : We also successfully onboarded the android version of bither, and we'd love to have you use buddybuild for both versions of your app!